### PR TITLE
Scryfall mtggoldish fixes

### DIFF
--- a/frontend/src/ComboContainer.tsx
+++ b/frontend/src/ComboContainer.tsx
@@ -120,7 +120,7 @@ export const ComboContainer: FC = () => {
             )}
           </h1>
           <p className="subtitle mb-2">by {deckData?.meta.author}</p>
-          {(allCombos?.included?.length ?? -1 > 0) && (
+          {(allCombos?.included?.length ?? -1) > 0 && (
             <p className="help">
               Click a combo to see its prerequisites and steps
             </p>

--- a/server/app/const.py
+++ b/server/app/const.py
@@ -1,0 +1,2 @@
+USER_AGENT = "MTGCombinator - infinite combos, finite braincells (https://github.com/naught0/combinator) v0.1.0"
+ACCEPT = "application/json"

--- a/server/app/logs.py
+++ b/server/app/logs.py
@@ -1,0 +1,3 @@
+import logging
+
+logger = logging.getLogger("uvicorn.error")


### PR DESCRIPTION
Scryfall would error sometimes due to empty entries being passed to in the name array. The primary culprit was mtggoldish due to some HTML parsing or something that I didn't delve further into

Now Scryfall requests are sent with a user agent and an accepts header per:  
https://scryfall.com/blog/user-agent-and-accept-header-now-required-on-the-api-225

Fixed a bug where a literal '0' was appearing when nothing should be rendered.